### PR TITLE
Fix response detection

### DIFF
--- a/Lycia.Infrastructure/Dispatching/SagaDispatcher.cs
+++ b/Lycia.Infrastructure/Dispatching/SagaDispatcher.cs
@@ -149,7 +149,7 @@ public class SagaDispatcher(
     {
         var messageType = message.GetType();
 
-        if (typeof(IResponse<>).IsAssignableFrom(messageType) &&
+        if (IsResponse(messageType) &&
             (IsEvent(messageType) || IsCommand(messageType)))
         {
             return;
@@ -357,6 +357,9 @@ public class SagaDispatcher(
             // throw new InvalidOperationException($"Step {stepTypeToCheck.Name} was not marked as completed/failed/compensated.");
         }
     }
+
+    private static bool IsResponse(Type type) =>
+        type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IResponse<>));
 
     private static bool IsSuccessResponse(Type type) =>
         type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ISuccessResponse<>));


### PR DESCRIPTION
## Summary
- ensure `SagaDispatcher` recognizes response messages by checking implemented interfaces

## Testing
- `dotnet test Lycia.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6841844cceac8321b984d7e493805d3d